### PR TITLE
Remove schema migration code

### DIFF
--- a/file_indexer/indexer.py
+++ b/file_indexer/indexer.py
@@ -109,8 +109,6 @@ class FileIndexer:
         CREATE INDEX IF NOT EXISTS idx_file_size ON files(file_size);
         """)
 
-
-
     def _should_process_file(
         self, file_path: str | Path, check_empty_files: bool = False
     ) -> bool:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -480,8 +480,6 @@ class TestFileIndexer:
         finally:
             calc_indexer.close()
 
-
-
     def test_batch_processing(self):
         """Test that batch processing works correctly."""
         # Reset counters

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -480,21 +480,7 @@ class TestFileIndexer:
         finally:
             calc_indexer.close()
 
-    def test_schema_migration(self):
-        """Test that schema migration works correctly."""
-        # This test is mainly to ensure the migration code doesn't crash
-        # The actual migration would require creating an old-format database
 
-        # Create a new indexer and verify it works
-        migration_indexer = FileIndexer(str(self.db_path) + "_migration")
-
-        try:
-            migration_indexer.update_database(self.test_files_dir, recursive=False)
-            stats = migration_indexer.get_stats()
-            assert stats["total_files"] > 0
-
-        finally:
-            migration_indexer.close()
 
     def test_batch_processing(self):
         """Test that batch processing works correctly."""


### PR DESCRIPTION
- Remove _migrate_schema() method from FileIndexer class
- Remove call to _migrate_schema() in __init__ method
- Remove test_schema_migration() test method
- Schema migration is no longer needed as all new databases are created with nullable checksum column

Fixes #21